### PR TITLE
Add support for Bravyi-Kitaev transformation in UCCSD ansatz

### DIFF
--- a/src/python/zquantum/vqe/singlet_uccsd.py
+++ b/src/python/zquantum/vqe/singlet_uccsd.py
@@ -3,11 +3,11 @@ from zquantum.core.interfaces.ansatz_utils import (
     ansatz_property,
     invalidates_parametrized_circuit,
 )
-from zquantum.core.circuit import Circuit, Gate, Qubit
+from zquantum.core.circuit import Circuit
 from openfermion.utils import uccsd_singlet_paramsize, uccsd_singlet_generator
 from overrides import overrides
-from .utils import exponentiate_fermion_operator
-from typing import List, Optional
+from .utils import exponentiate_fermion_operator, build_hartree_fock_circuit
+from typing import Optional
 import numpy as np
 
 
@@ -103,13 +103,12 @@ class SingletUCCSDAnsatz(Ansatz):
         Args:
             params: parameters of the circuit. 
         """
-        circuit = Circuit()
-        circuit.gates = []
-
-        # Prepare initial state
-        for i in range(self.number_of_electrons):
-            qubit_index = self.number_of_electrons - i - 1
-            circuit.gates.append(Gate("X", [Qubit(qubit_index)]))
+        circuit = build_hartree_fock_circuit(
+            self.number_of_qubits,
+            self.number_of_alpha_electrons,
+            self._number_of_beta_electrons,
+            self._transformation,
+        )
 
         # Build UCCSD generator
         fermion_generator = uccsd_singlet_generator(
@@ -120,7 +119,7 @@ class SingletUCCSDAnsatz(Ansatz):
         )
 
         evolution_operator = exponentiate_fermion_operator(
-            fermion_generator, self._transformation
+            fermion_generator, self._transformation, self.number_of_qubits,
         )
 
         circuit += evolution_operator

--- a/src/python/zquantum/vqe/utils.py
+++ b/src/python/zquantum/vqe/utils.py
@@ -1,26 +1,28 @@
-from zquantum.core.circuit import Circuit
+from zquantum.core.circuit import Circuit, Gate, Qubit
 from forestopenfermion import exponentiate
 from openfermion import (
     jordan_wigner,
     bravyi_kitaev,
     FermionOperator,
     InteractionOperator,
+    get_fermion_operator,
 )
 import numpy as np
-from typing import Union
+from typing import Optional, Union
 
 
 def exponentiate_fermion_operator(
     fermion_generator: Union[FermionOperator, InteractionOperator],
     transformation: str = "Jordan-Wigner",
+    number_of_qubits: Optional[int] = None,
 ) -> Circuit:
     """Create a circuit corresponding to the exponentiation of an operator. Works only for antihermitian fermionic operators.
 
     Args:
         fermion_generator (openfermion.FermionOperator or 
             openfermion.InteractionOperator): fermionic generator.
-        fermion_transform (str): The name of the qubit to fermion transformation
-            to use.
+        transformation (str): The name of the qubit-to-fermion transformation to use.
+        number_of_qubits (int): The number of qubits in the system. Defaults to None.
 
     Returns:
         zquantum.core.circuit.Circuit: Circuit corresponding to the exponentiation of the
@@ -31,11 +33,11 @@ def exponentiate_fermion_operator(
 
     # Transform generator to qubits
     if transformation == "Jordan-Wigner":
-        transformation = jordan_wigner
-    elif transformation == "Bravyi-Kitaev":
-        transformation = bravyi_kitaev
-
-    qubit_generator = transformation(fermion_generator)
+        qubit_generator = jordan_wigner(fermion_generator)
+    else:
+        if isinstance(fermion_generator, InteractionOperator):
+            fermion_generator = get_fermion_operator(fermion_generator)
+        qubit_generator = bravyi_kitaev(fermion_generator, n_qubits=number_of_qubits)
 
     for term in qubit_generator.terms:
         if not np.isclose(qubit_generator.terms[term].real, 0.0):
@@ -47,3 +49,53 @@ def exponentiate_fermion_operator(
     circuit = exponentiate(qubit_generator)
 
     return Circuit(circuit)
+
+
+def build_hartree_fock_circuit(
+    number_of_qubits: int,
+    number_of_alpha_electrons: int,
+    number_of_beta_electrons: int,
+    transformation: str,
+    spin_ordering: str = "interleaved",
+) -> Circuit:
+    """Creates a circuit that prepares the Hartree-Fock state.  
+
+    Args:
+        number_of_qubits (int): the number of qubits in the system.
+        number_of_alpha_electrons (int): the number of alpha electrons in the system.
+        number_of_beta_electrons (int): the number of beta electrons in the system.
+        transformation (str): the Hamiltonian transformation to use. 
+        spin_ordering (str, optional): the spin ordering convention to use. Defaults to "interleaved".
+    
+    Returns:
+        zquantum.core.circuit.Circuit: a circuit that prepares the Hartree-Fock state. 
+    """
+    if spin_ordering != "interleaved":
+        raise RuntimeError(
+            f"{spin_ordering} is not supported at this time. Interleaved is the only supported spin-ordering."
+        )
+    circuit = Circuit()
+    circuit.gates = []
+    alpha_indexes = list(range(0, number_of_qubits, 2))
+    beta_indexes = list(range(1, number_of_qubits, 2))
+    index_list = []
+    for index in alpha_indexes[:number_of_alpha_electrons]:
+        index_list.append(index)
+    for index in beta_indexes[:number_of_beta_electrons]:
+        index_list.append(index)
+    index_list.sort()
+    op_list = [(x, 1) for x in index_list]
+    fermion_op = FermionOperator(tuple(op_list), 1.0)
+    if transformation == "Jordan-Wigner":
+        transformed_op = jordan_wigner(fermion_op)
+    elif transformation == "Bravyi-Kitaev":
+        transformed_op = bravyi_kitaev(fermion_op, n_qubits=number_of_qubits)
+    else:
+        raise RuntimeError(
+            f"{transformation} is not a supported transformation. Jordan-Wigner and Bravyi-Kitaev are supported at this time."
+        )
+    term = next(iter(transformed_op.terms.items()))
+    for op in term[0]:
+        if op[1] != "Z":
+            circuit.gates.append(Gate("X", [Qubit(op[0])]))
+    return circuit

--- a/src/python/zquantum/vqe/utils.py
+++ b/src/python/zquantum/vqe/utils.py
@@ -22,7 +22,9 @@ def exponentiate_fermion_operator(
         fermion_generator (openfermion.FermionOperator or 
             openfermion.InteractionOperator): fermionic generator.
         transformation (str): The name of the qubit-to-fermion transformation to use.
-        number_of_qubits (int): The number of qubits in the system. Defaults to None.
+        number_of_qubits (int|None): This can be used to force the number of qubits in the resulting operator 
+            above the number that appears in the input operator. Defaults to None and the number of qubits in 
+            the resulting operator will match the number that appears in the input operator. 
 
     Returns:
         zquantum.core.circuit.Circuit: Circuit corresponding to the exponentiation of the

--- a/src/python/zquantum/vqe/utils_test.py
+++ b/src/python/zquantum/vqe/utils_test.py
@@ -1,6 +1,35 @@
 import unittest
-from .utils import exponentiate_fermion_operator
+from zquantum.core.circuit import Circuit, Qubit, Gate
+from .utils import exponentiate_fermion_operator, build_hartree_fock_circuit
 
 
 class TestVQEUtils(unittest.TestCase):
-    pass
+    def test_build_hartree_fock_circuit_jordan_wigner(self):
+        number_of_qubits = 4
+        number_of_alpha_electrons = 1
+        number_of_beta_electrons = 1
+        transformation = "Jordan-Wigner"
+        expected_circuit = Circuit()
+        expected_circuit.gates = [Gate("X", [Qubit(0)]), Gate("X", [Qubit(1)])]
+        actual_circuit = build_hartree_fock_circuit(
+            number_of_qubits,
+            number_of_alpha_electrons,
+            number_of_beta_electrons,
+            transformation,
+        )
+        self.assertEqual(actual_circuit, expected_circuit)
+
+    def test_build_hartree_fock_circuit_bravyi_kitaev(self):
+        number_of_qubits = 4
+        number_of_alpha_electrons = 1
+        number_of_beta_electrons = 1
+        transformation = "Bravyi-Kitaev"
+        expected_circuit = Circuit()
+        expected_circuit.gates = [Gate("X", [Qubit(0)])]
+        actual_circuit = build_hartree_fock_circuit(
+            number_of_qubits,
+            number_of_alpha_electrons,
+            number_of_beta_electrons,
+            transformation,
+        )
+        self.assertEqual(actual_circuit, expected_circuit)


### PR DESCRIPTION
The UCCSD ansatz uses the HF state as the initial state. This PR prepares that initial state depending on the transformation (JW or BK) used. 

(Note: I confirmed that this works with the H2 VQE workflow.)