### PR TITLE
ZQS-665 update example workflow to remove psi4 runtime

### DIFF
--- a/examples/hydrogen-vqe.yaml
+++ b/examples/hydrogen-vqe.yaml
@@ -63,7 +63,7 @@ steps:
   passed: [create-molecule]
   config:
     runtime:
-      language: psi4
+      language: python3
       customImage: "zapatacomputing/qe-psi4"
       imports: [z-quantum-core, qe-psi4]
       parameters:


### PR DESCRIPTION
Updates the example workflow to use the python3 runtime instead of the psi4 runtime. I manually confirmed that the new workflow completes successfully.